### PR TITLE
Added ErrorClass 'communication'

### DIFF
--- a/py27/bacpypes/basetypes.py
+++ b/py27/bacpypes/basetypes.py
@@ -707,6 +707,7 @@ class ErrorClass(Enumerated):
         , 'security':4
         , 'services':5
         , 'vt':6
+        , 'communication':7
         }
 
 class ErrorCode(Enumerated):


### PR DESCRIPTION
The ASHRAE standard 135-2012 defines in section 18.7 "_Error Class - COMMUNICATION_" (page 600) another BACnet error class that seems to be missing from bacpypes. According to section 21 "_Formal description of application protocol data units_" (page 655)  its enumeration is 7.

We actually encountered this error class in responses from a North BT Commander. 

I only added the patch to the py27 subtree - Not sure how you manage the three version subtrees (?)