### PR TITLE
Fix segment ack read from network

### DIFF
--- a/py25/bacpypes/apdu.py
+++ b/py25/bacpypes/apdu.py
@@ -501,17 +501,6 @@ class SegmentAckPDU(_APDU):
         if _debug: SegmentAckPDU._debug("__init__ %r %r %r %r %r %r %r", nak, srv, invokeID, sequenceNumber, windowSize, args, kwargs)
         super(SegmentAckPDU, self).__init__(*args, **kwargs)
 
-        if nak is None:
-            raise ValueError("nak is None")
-        if srv is None:
-            raise ValueError("srv is None")
-        if invokeID is None:
-            raise ValueError("invokeID is None")
-        if sequenceNumber is None:
-            raise ValueError("sequenceNumber is None")
-        if windowSize is None:
-            raise ValueError("windowSize is None")
-
         self.apduType = SegmentAckPDU.pduType
         self.apduNak = nak
         self.apduSrv = srv

--- a/py25/bacpypes/appservice.py
+++ b/py25/bacpypes/appservice.py
@@ -114,7 +114,9 @@ class SSM(OneShotTask, DebugContents):
     def stop_timer(self):
         if _debug: SSM._debug("stop_timer")
 
-        self.suspend_task()
+        # if this is active, pull it
+        if self.isScheduled:
+            self.suspend_task()
 
     def restart_timer(self, msecs):
         if _debug: SSM._debug("restart_timer %r", msecs)

--- a/py27/bacpypes/apdu.py
+++ b/py27/bacpypes/apdu.py
@@ -499,17 +499,6 @@ class SegmentAckPDU(_APDU):
         if _debug: SegmentAckPDU._debug("__init__ %r %r %r %r %r %r %r", nak, srv, invokeID, sequenceNumber, windowSize, args, kwargs)
         super(SegmentAckPDU, self).__init__(*args, **kwargs)
 
-        if nak is None:
-            raise ValueError("nak is None")
-        if srv is None:
-            raise ValueError("srv is None")
-        if invokeID is None:
-            raise ValueError("invokeID is None")
-        if sequenceNumber is None:
-            raise ValueError("sequenceNumber is None")
-        if windowSize is None:
-            raise ValueError("windowSize is None")
-
         self.apduType = SegmentAckPDU.pduType
         self.apduNak = nak
         self.apduSrv = srv

--- a/py27/bacpypes/appservice.py
+++ b/py27/bacpypes/appservice.py
@@ -115,7 +115,9 @@ class SSM(OneShotTask, DebugContents):
     def stop_timer(self):
         if _debug: SSM._debug("stop_timer")
 
-        self.suspend_task()
+        # if this is active, pull it
+        if self.isScheduled:
+            self.suspend_task()
 
     def restart_timer(self, msecs):
         if _debug: SSM._debug("restart_timer %r", msecs)
@@ -1395,4 +1397,3 @@ class ApplicationServiceAccessPoint(ApplicationServiceElement, ServiceAccessPoin
 
         # forward the encoded packet
         self.response(xpdu)
-

--- a/py34/bacpypes/apdu.py
+++ b/py34/bacpypes/apdu.py
@@ -499,17 +499,6 @@ class SegmentAckPDU(_APDU):
         if _debug: SegmentAckPDU._debug("__init__ %r %r %r %r %r %r %r", nak, srv, invokeID, sequenceNumber, windowSize, args, kwargs)
         super(SegmentAckPDU, self).__init__(*args, **kwargs)
 
-        if nak is None:
-            raise ValueError("nak is None")
-        if srv is None:
-            raise ValueError("srv is None")
-        if invokeID is None:
-            raise ValueError("invokeID is None")
-        if sequenceNumber is None:
-            raise ValueError("sequenceNumber is None")
-        if windowSize is None:
-            raise ValueError("windowSize is None")
-
         self.apduType = SegmentAckPDU.pduType
         self.apduNak = nak
         self.apduSrv = srv

--- a/py34/bacpypes/appservice.py
+++ b/py34/bacpypes/appservice.py
@@ -115,7 +115,9 @@ class SSM(OneShotTask, DebugContents):
     def stop_timer(self):
         if _debug: SSM._debug("stop_timer")
 
-        self.suspend_task()
+        # if this is active, pull it
+        if self.isScheduled:
+            self.suspend_task()
 
     def restart_timer(self, msecs):
         if _debug: SSM._debug("restart_timer %r", msecs)


### PR DESCRIPTION
Fixes following issues 
1. While reading segment ack package from network, the code is not able to de-searilize the message.
2. Error in sending subsequent REQ messages once segment ack is received for first message.