### PR TITLE
Fix setup.py for Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ source_folder = {
     (2, 7): 'py27',
     (3, 4): 'py34',
     (3, 5): 'py34',
+    (3, 6): 'py34',
     }.get(version_info, None)
 if not source_folder:
     raise EnvironmentError("unsupported version of Python")
@@ -75,6 +76,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 
     setup_requires=setup_requirements,


### PR DESCRIPTION
Setup.py is not compatible with Python 3.6.
This Pull Request tries to fix the issue.
With the proposed changes it is possible to run `python setup.py install` on python 3.6.3 (windows).
However, after installing for development with `python setup.py develop`, there is an error on import:
`ModuleNotFoundError: No module named 'bacnet'`
This only addresses the problems when running setup.py manually. The pip install is working fine on py 3.6