### PR TITLE
IOCB.wait(): return timeout state in Python 3

### DIFF
--- a/py34/bacpypes/iocb.py
+++ b/py34/bacpypes/iocb.py
@@ -141,12 +141,12 @@ class IOCB(DebugContents):
         if self.ioComplete.isSet():
             self.trigger()
 
-    def wait(self, *args):
+    def wait(self, *args, **kwargs):
         """Wait for the completion event to be set."""
-        if _debug: IOCB._debug("wait(%d) %r", self.ioID, args)
+        if _debug: IOCB._debug("wait(%d) %r %r", self.ioID, args, kwargs)
 
         # waiting from a non-daemon thread could be trouble
-        self.ioComplete.wait(*args)
+        return self.ioComplete.wait(*args, **kwargs)
 
     def trigger(self):
         """Set the completion event and make the callback(s)."""


### PR DESCRIPTION
The [Condition.wait()](https://docs.python.org/3/library/threading.html#threading.Condition.wait) from Python 3.2 on returns "`True` unless a given timeout expired, in which case it is `False`". When using IOCB.wait() with a timeout, it can be useful to have this return value. This PR adds this `return` statement.