### PR TITLE
Clause 6.6.2

### DIFF
--- a/py27/bacpypes/bacpypes
+++ b/py27/bacpypes/bacpypes
@@ -1,1 +1,0 @@
-/Users/modiji/amit/bacpypes/py27/bacpypes

--- a/py27/bacpypes/bacpypes
+++ b/py27/bacpypes/bacpypes
@@ -1,0 +1,1 @@
+/Users/modiji/amit/bacpypes/py27/bacpypes

--- a/py27/bacpypes/netservice.py
+++ b/py27/bacpypes/netservice.py
@@ -947,9 +947,12 @@ class NetworkServiceElement(ApplicationServiceElement):
                 # network provided. netList must have only this network
                 # and should be sent out to all adapters
                 self.send_iamrtn_all_for_network(network)
+                return
 
             # destination as well as  network is provided
-            adapter = self.elementService.adapters[network]
+            adapter = self.elementService.adapters.get(network)
+            if not adapter:
+                raise RuntimeError("No adapter for network %r", network)
             iamrtn = IAmRouterToNetwork(netList=[network])
             iamrtn.pduDestination = destination if isinstance(destination, Address) else Address(destination)
             log("sending IAmRouterToNetwork %r %r", adapter, network)

--- a/py27/bacpypes/netservice.py
+++ b/py27/bacpypes/netservice.py
@@ -886,4 +886,82 @@ class NetworkServiceElement(ApplicationServiceElement):
 
         # reference the service access point
         # sap = self.elementService
+    def send_iamrtn_all(self):
+        """
+        Send IAMRouterToNetwork with netList for all adapters sans the current
+        adapter
+        :return: None
+        """
+        log = NetworkServiceElement._debug
+        if _debug: log("send_iamrtn_all")
+        adapters = self.elementService.adapters.values()
+        routes = {}  # key = adapter, value = list of networks for all other adapters.
+
+        for adapter in adapters:
+            routes[adapter] = []
+
+        # build the netList
+        for current_adapter, netList in routes.items():
+            other_adapters = list(set(adapters) - set([current_adapter]))
+
+            # directly reachable network
+            for adapter in other_adapters:
+                netList.append(adapter.adapterNet)
+
+        destination = LocalBroadcast()
+        for adapter, netList in routes.items():
+            if netList:
+                iamrtn = IAmRouterToNetwork(netList=netList)
+                iamrtn.pduDestination = destination
+                if _debug: log("sending  IAmRouterToNetwork %r %r", adapter, iamrtn)
+                self.request(adapter, iamrtn)
+
+    def send_iamrtn_all_for_network(self, network):
+        """
+        Send this network[dnet] info to all adapters
+        :param network:
+        :return:None
+        """
+        log = NetworkServiceElement._debug
+        netList = [network]
+
+        for adapter in self.elementService.adapters.values():
+            iamrtn = IAmRouterToNetwork(netList=netList)
+            iamrtn.pduDestination = LocalBroadcast()
+            if _debug: log("sending  IAmRouterToNetwork %r %r", adapter, iamrtn)
+            self.request(adapter, iamrtn)
+
+    def send_iamrtn(self, adapter=None, destination=None, network=None):
+        log = NetworkServiceElement._debug
+
+        if not adapter:
+            if not network and not destination:
+                # no adapter, no destination, no network
+                # unhinged request akin to response to WhoIsRouter
+                self.send_iamrtn_all()
+                return
+
+            if not destination:
+                # network provided. netList must have only this network
+                # and should be sent out to all adapters
+                self.send_iamrtn_all_for_network(network)
+
+            # destination as well as  network is provided
+            adapter = self.elementService.adapters[network]
+            iamrtn = IAmRouterToNetwork(netList=[network])
+            iamrtn.pduDestination = destination if isinstance(destination, Address) else Address(destination)
+            self.request(adapter, iamrtn)
+            return
+
+        destination = destination if destination else LocalBroadcast()
+
+        if adapter != self.elementService.adapters[network]:
+            if _debug:
+                log("Supplied adapter not of the supplied network")
+            return
+
+        iamrtn = IAmRouterToNetwork(netList=[network])
+        iamrtn.pduDestination = destination
+        self.request(adapter, iamrtn)
+        return
 

--- a/py27/bacpypes/netservice.py
+++ b/py27/bacpypes/netservice.py
@@ -934,6 +934,8 @@ class NetworkServiceElement(ApplicationServiceElement):
     def send_iamrtn(self, adapter=None, destination=None, network=None):
         log = NetworkServiceElement._debug
 
+        if _debug: log("send_iamrtn")
+
         if not adapter:
             if not network and not destination:
                 # no adapter, no destination, no network
@@ -950,6 +952,7 @@ class NetworkServiceElement(ApplicationServiceElement):
             adapter = self.elementService.adapters[network]
             iamrtn = IAmRouterToNetwork(netList=[network])
             iamrtn.pduDestination = destination if isinstance(destination, Address) else Address(destination)
+            log("sending IAmRouterToNetwork %r %r", adapter, network)
             self.request(adapter, iamrtn)
             return
 
@@ -960,11 +963,12 @@ class NetworkServiceElement(ApplicationServiceElement):
 
         if adapter != self.elementService.adapters[network]:
             if _debug:
-                log("Supplied adapter not of the supplied network")
+                log("Adapter not of network %r", network)
             return
 
         iamrtn = IAmRouterToNetwork(netList=[network])
         iamrtn.pduDestination = destination
+        if _debug: log("sending IAmRouterToNetwork %r %r", adapter, network)
         self.request(adapter, iamrtn)
         return
 

--- a/py27/bacpypes/netservice.py
+++ b/py27/bacpypes/netservice.py
@@ -953,7 +953,10 @@ class NetworkServiceElement(ApplicationServiceElement):
             self.request(adapter, iamrtn)
             return
 
-        destination = destination if destination else LocalBroadcast()
+        if not destination:
+            destination = LocalBroadcast()
+        else:
+            destination = destination if isinstance(destination, Address) else Address(destination)
 
         if adapter != self.elementService.adapters[network]:
             if _debug:

--- a/py34/bacpypes/netservice.py
+++ b/py34/bacpypes/netservice.py
@@ -948,9 +948,12 @@ class NetworkServiceElement(ApplicationServiceElement):
                 # network provided. netList must have only this network
                 # and should be sent out to all adapters
                 self.send_iamrtn_all_for_network(network)
+                return
 
             # destination as well as  network is provided
-            adapter = self.elementService.adapters[network]
+            adapter = self.elementService.adapters.get(network)
+            if not adapter:
+                raise RuntimeError("No adapter for network %r", network)
             iamrtn = IAmRouterToNetwork(netList=[network])
             iamrtn.pduDestination = destination if isinstance(destination, Address) else Address(destination)
             log("sending IAmRouterToNetwork %r %r", adapter, network)

--- a/py34/bacpypes/netservice.py
+++ b/py34/bacpypes/netservice.py
@@ -954,7 +954,10 @@ class NetworkServiceElement(ApplicationServiceElement):
             self.request(adapter, iamrtn)
             return
 
-        destination = destination if destination else LocalBroadcast()
+        if not destination:
+            destination = LocalBroadcast()
+        else:
+            destination = destination if isinstance(destination, Address) else Address(destination)
 
         if adapter != self.elementService.adapters[network]:
             if _debug:

--- a/py34/bacpypes/netservice.py
+++ b/py34/bacpypes/netservice.py
@@ -935,6 +935,8 @@ class NetworkServiceElement(ApplicationServiceElement):
     def send_iamrtn(self, adapter=None, destination=None, network=None):
         log = NetworkServiceElement._debug
 
+        if _debug: log("send_iamrtn")
+
         if not adapter:
             if not network and not destination:
                 # no adapter, no destination, no network
@@ -951,6 +953,7 @@ class NetworkServiceElement(ApplicationServiceElement):
             adapter = self.elementService.adapters[network]
             iamrtn = IAmRouterToNetwork(netList=[network])
             iamrtn.pduDestination = destination if isinstance(destination, Address) else Address(destination)
+            log("sending IAmRouterToNetwork %r %r", adapter, network)
             self.request(adapter, iamrtn)
             return
 
@@ -961,11 +964,12 @@ class NetworkServiceElement(ApplicationServiceElement):
 
         if adapter != self.elementService.adapters[network]:
             if _debug:
-                log("Supplied adapter not of the supplied network")
+                log("Adapter not of network %r", network)
             return
 
         iamrtn = IAmRouterToNetwork(netList=[network])
         iamrtn.pduDestination = destination
+        if _debug: log("sending IAmRouterToNetwork %r %r", adapter, network)
         self.request(adapter, iamrtn)
         return
 

--- a/py34/bacpypes/netservice.py
+++ b/py34/bacpypes/netservice.py
@@ -887,3 +887,83 @@ class NetworkServiceElement(ApplicationServiceElement):
         # reference the service access point
         # sap = self.elementService
 
+    def send_iamrtn_all(self):
+        """
+        Send IAMRouterToNetwork with netList for all adapters sans the current
+        adapter
+        :return: None
+        """
+        log = NetworkServiceElement._debug
+        if _debug: log("send_iamrtn_all")
+        adapters = self.elementService.adapters.values()
+        routes = {}  # key = adapter, value = list of networks for all other adapters.
+
+        for adapter in adapters:
+            routes[adapter] = []
+
+        # build the netList
+        for current_adapter, netList in routes.items():
+            other_adapters = list(set(adapters) - set([current_adapter]))
+
+            # directly reachable network
+            for adapter in other_adapters:
+                netList.append(adapter.adapterNet)
+
+        destination = LocalBroadcast()
+        for adapter, netList in routes.items():
+            if netList:
+                iamrtn = IAmRouterToNetwork(netList=netList)
+                iamrtn.pduDestination = destination
+                if _debug: log("sending  IAmRouterToNetwork %r %r", adapter, iamrtn)
+                self.request(adapter, iamrtn)
+
+    def send_iamrtn_all_for_network(self, network):
+        """
+        Send this network[dnet] info to all adapters
+        :param network:
+        :return:None
+        """
+        log = NetworkServiceElement._debug
+        netList = [network]
+
+        for adapter in self.elementService.adapters.values():
+            iamrtn = IAmRouterToNetwork(netList=netList)
+            iamrtn.pduDestination = LocalBroadcast()
+            if _debug: log("sending  IAmRouterToNetwork %r %r", adapter, iamrtn)
+            self.request(adapter, iamrtn)
+
+    def send_iamrtn(self, adapter=None, destination=None, network=None):
+        log = NetworkServiceElement._debug
+
+        if not adapter:
+            if not network and not destination:
+                # no adapter, no destination, no network
+                # unhinged request akin to response to WhoIsRouter
+                self.send_iamrtn_all()
+                return
+
+            if not destination:
+                # network provided. netList must have only this network
+                # and should be sent out to all adapters
+                self.send_iamrtn_all_for_network(network)
+
+            # destination as well as  network is provided
+            adapter = self.elementService.adapters[network]
+            iamrtn = IAmRouterToNetwork(netList=[network])
+            iamrtn.pduDestination = destination if isinstance(destination, Address) else Address(destination)
+            self.request(adapter, iamrtn)
+            return
+
+        destination = destination if destination else LocalBroadcast()
+
+        if adapter != self.elementService.adapters[network]:
+            if _debug:
+                log("Supplied adapter not of the supplied network")
+            return
+
+        iamrtn = IAmRouterToNetwork(netList=[network])
+        iamrtn.pduDestination = destination
+        self.request(adapter, iamrtn)
+        return
+
+

--- a/samples/IP2IPRouter.py
+++ b/samples/IP2IPRouter.py
@@ -21,7 +21,7 @@ As a router, this does not have an application layer.
 from bacpypes.debugging import bacpypes_debugging, ModuleLogger
 from bacpypes.consolelogging import ArgumentParser
 
-from bacpypes.core import run
+from bacpypes.core import run, deferred
 from bacpypes.comm import bind
 
 from bacpypes.pdu import Address
@@ -117,6 +117,7 @@ def main():
 
     # create the router
     router = IP2IPRouter(Address(args.addr1), args.net1, Address(args.addr2), args.net2)
+    deferred(router.send_iamrtn)
     if _debug: _log.debug("    - router: %r", router)
 
     _log.debug("running")

--- a/samples/IP2IPRouter.py
+++ b/samples/IP2IPRouter.py
@@ -77,6 +77,10 @@ class IP2IPRouter:
         # bind the BIP stack to the local network
         self.nsap.bind(self.s2_bip, net2)
 
+    def send_iamrtn(self):
+        if _debug: IP2IPRouter._debug("send_iamrtn")
+        self.nse.send_iamrtn()
+
 #
 #   __main__
 #

--- a/samples/IP2VLANRouter.py
+++ b/samples/IP2VLANRouter.py
@@ -15,7 +15,7 @@ import argparse
 from bacpypes.debugging import bacpypes_debugging, ModuleLogger
 from bacpypes.consolelogging import ArgumentParser
 
-from bacpypes.core import run
+from bacpypes.core import run, deferred
 from bacpypes.comm import bind
 
 from bacpypes.pdu import Address, LocalBroadcast
@@ -257,6 +257,8 @@ def main():
 
         # add it to the device
         vlan_app.add_object(ravo)
+
+    deferred(vlan_app.send_iamrtn)
 
     _log.debug("running")
 

--- a/samples/IP2VLANRouter.py
+++ b/samples/IP2VLANRouter.py
@@ -135,6 +135,10 @@ class VLANApplication(Application, WhoIsIAmServices, ReadWritePropertyServices):
         if _debug: VLANApplication._debug("[%s]confirmation %r", self.vlan_node.address, apdu)
         Application.confirmation(self, apdu)
 
+    def send_iamrtn(self):
+        if _debug: VLANApplication._debug("send_iamrtn")
+        self.nse.send_iamrtn()
+
 #
 #   VLANRouter
 #


### PR DESCRIPTION
[112](https://github.com/JoelBender/bacpypes/issues/211) `IAmRouterToNetwork` helper methods in `NetService`.

`def i_am_router_to_network(self, adapter=None, destination=None, network=None):
`

`IAmRouterToNetwork` sent out by `adapters` with different `netList`  and different `address` depending upon the supplied arguments to the method.

- If all three arguments are None: `IAmRouterToNetwork` is sent out on all `adapters` with different `netLists`.
- If an `adapter` is provided, the `destination` must be a `local station address`, `local broadcast address,` a `remote station address` with a network number that matches the adapter, or a remote broadcast address that matches
- If `network` and `destination` is provided, `IAmRouterToNetwork`  is sent out on all `adapters` with `netList` which has only the provided `network`