### PR TITLE
under Updating the INI file

### DIFF
--- a/doc/source/gettingstarted/gettingstarted001.rst
+++ b/doc/source/gettingstarted/gettingstarted001.rst
@@ -137,7 +137,7 @@ configure the BACnet portion of your workstation.  Change into the
 samples directory that you checked out earlier, make a copy
 of the sample configuration file, and edit it for your site::
 
-    $ cd bacpypes/samples
+    $ cd bacpypes
     $ cp BACpypes~.ini BACpypes.ini
 
 .. tip:: 


### PR DESCRIPTION
$ cd bacpypes/samples
$ cp BACpypes~.ini BACpypes.ini
> that does not work currently as BACpypes~.ini is found in the root bacpypes directory.