### PR TITLE
Handle error on socket binding

### DIFF
--- a/py34/bacpypes/udp.py
+++ b/py34/bacpypes/udp.py
@@ -151,7 +151,12 @@ class UDPDirector(asyncore.dispatcher, Server, ServiceAccessPoint):
             self.set_reuse_addr()
 
         # proceed with the bind
-        self.bind(address)
+        try:
+            self.bind(address)
+        except:
+            self.close()
+            raise
+
         if _debug: UDPDirector._debug("    - getsockname: %r", self.socket.getsockname())
 
         # allow it to send broadcasts


### PR DESCRIPTION
This fixes a problem where UDPDirector tries to bind
on an address but that address is already in use. In that
case the bind fails but the UDPDirector instance still stays
in the asyncore.dispatcher from the call to the super class
initializer.

The bind error will then propagate to the top so it can be
handled by the higher level. If the high level application
responds to the error by asking to bind on a new address
(another port) and this one succeeds, the code will go on
and fail later on when processing asyncore.loop.

This is because the previous failed UDPDirector instance is
still present in asyncore but cannot be processed due to
its previous initialization failure.

The call to close() in case of an error ensures that the
dispatcher correctly frees the allocated resources for the
UDPDirector instance.