### PR TITLE
Out of service | Change mutability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ source_folder = {
     (3, 4): 'py34',
     (3, 5): 'py34',
     (3, 6): 'py34',
+    (3, 7): 'py34',
     }.get(version_info, None)
 if not source_folder:
     raise EnvironmentError("unsupported version of Python")


### PR DESCRIPTION
Some object properties must be writable if the out_of_service property is True.

This PR present an attempt to make that work at the object level, allowing a property to be mutable when outOfService is True.

The complete object List would need to be modified.
I've implemented the change on the AnalogInputObject only adding this new parameter : 

```
@register_object_type
class AnalogInputObject(Object):
    objectType = 'analogInput'
    properties = \
        [ ReadableProperty('presentValue', Real, writable_if_oos=True)
        , OptionalProperty('deviceType', CharacterString)
        , ReadableProperty('statusFlags', StatusFlags)
        , ReadableProperty('eventState', EventState)
        , OptionalProperty('reliability', Reliability, writable_if_oos=True)
    #[...]
```

