### PR TITLE
Fix for issue #299: Unhandled TypeError in case of segmented confirmed request message transmission

### DIFF
--- a/py34/bacpypes/appservice.py
+++ b/py34/bacpypes/appservice.py
@@ -530,7 +530,11 @@ class ClientSSM(SSM):
 
             self.segmentRetryCount += 1
             self.start_timer(self.segmentTimeout)
-            self.fill_window(self.initialSequenceNumber)
+
+            if self.initialSequenceNumber == 0:
+                self.request(self.get_segment(0))
+            else:
+                self.fill_window(self.initialSequenceNumber)
         else:
             if _debug: ClientSSM._debug("    - abort, no response from the device")
 


### PR DESCRIPTION
The fix is quite basic: when handling a segmented request timeout I look at the sequence number and if we haven't sent segment 0 yet then reattempt that instead of trying to fill the window and consequently fail by raising the TypeError.