### PR TITLE
🐛 Use the correct field name when retrieving the segment timeout from a device object

### DIFF
--- a/py25/bacpypes/appservice.py
+++ b/py25/bacpypes/appservice.py
@@ -84,7 +84,7 @@ class SSM(OneShotTask, DebugContents):
         self.apduTimeout = getattr(sap.localDevice, 'apduTimeout', sap.apduTimeout)
 
         self.segmentationSupported = getattr(sap.localDevice, 'segmentationSupported', sap.segmentationSupported)
-        self.segmentTimeout = getattr(sap.localDevice, 'segmentTimeout', sap.segmentTimeout)
+        self.segmentTimeout = getattr(sap.localDevice, 'apduSegmentTimeout', sap.segmentTimeout)
         self.maxSegmentsAccepted = getattr(sap.localDevice, 'maxSegmentsAccepted', sap.maxSegmentsAccepted)
         self.maxApduLengthAccepted = getattr(sap.localDevice, 'maxApduLengthAccepted', sap.maxApduLengthAccepted)
 

--- a/py27/bacpypes/appservice.py
+++ b/py27/bacpypes/appservice.py
@@ -85,7 +85,7 @@ class SSM(OneShotTask, DebugContents):
         self.apduTimeout = getattr(sap.localDevice, 'apduTimeout', sap.apduTimeout)
 
         self.segmentationSupported = getattr(sap.localDevice, 'segmentationSupported', sap.segmentationSupported)
-        self.segmentTimeout = getattr(sap.localDevice, 'segmentTimeout', sap.segmentTimeout)
+        self.segmentTimeout = getattr(sap.localDevice, 'apduSegmentTimeout', sap.segmentTimeout)
         self.maxSegmentsAccepted = getattr(sap.localDevice, 'maxSegmentsAccepted', sap.maxSegmentsAccepted)
         self.maxApduLengthAccepted = getattr(sap.localDevice, 'maxApduLengthAccepted', sap.maxApduLengthAccepted)
 

--- a/py34/bacpypes/appservice.py
+++ b/py34/bacpypes/appservice.py
@@ -85,7 +85,7 @@ class SSM(OneShotTask, DebugContents):
         self.apduTimeout = getattr(sap.localDevice, 'apduTimeout', sap.apduTimeout)
 
         self.segmentationSupported = getattr(sap.localDevice, 'segmentationSupported', sap.segmentationSupported)
-        self.segmentTimeout = getattr(sap.localDevice, 'segmentTimeout', sap.segmentTimeout)
+        self.segmentTimeout = getattr(sap.localDevice, 'apduSegmentTimeout', sap.segmentTimeout)
         self.maxSegmentsAccepted = getattr(sap.localDevice, 'maxSegmentsAccepted', sap.maxSegmentsAccepted)
         self.maxApduLengthAccepted = getattr(sap.localDevice, 'maxApduLengthAccepted', sap.maxApduLengthAccepted)
 


### PR DESCRIPTION
I haven't found any instance where 'segmentTimeout' is set on the device object. This looks like a mistake given that 'apduSegmentTimeout' is a property of the device object.